### PR TITLE
fix: run npm install before tsc in install.sh for fresh clones

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,8 @@ echo "[install.sh] Mode: $INSTALL_MODE" >&2
 
 # --- COMPILE (git mode only) ---
 if [ "$INSTALL_MODE" = "git" ]; then
+  echo "📦 Installing dependencies..."
+  (cd "$SCRIPT_DIR/extension" && npm install --no-fund --no-audit)
   echo "🔨 Compiling TypeScript..."
   (cd "$SCRIPT_DIR/extension" && npx tsc)
 else


### PR DESCRIPTION
### Summary

Add missing `npm` install step before TypeScript compilation in `install.sh`, fixing failure on fresh clones where `node_modules/` doesn't exist yet
